### PR TITLE
Declared include dir needed to find RVO header file in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ set(RVO_SOURCES
 	RVOSimulator.cpp)
 
 add_library(RVO ${RVO_HEADERS} ${RVO_SOURCES})
+target_include_directories(RVO PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(WIN32)
     set_target_properties(RVO PROPERTIES COMPILE_DEFINITIONS NOMINMAX)


### PR DESCRIPTION
I was adding the RVO library as a git submodule to my project, and in order to find the library's header file from my own code during build, I needed to add this line.

I think the issue was similar to this: https://stackoverflow.com/q/38022700

Not sure if there are more elegant ways to solve this, though. 